### PR TITLE
chore: upgrade dependencies weekly

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -4,7 +4,7 @@ name: upgrade
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -139,6 +139,12 @@ const repo = configureProject(
       }),
     },
 
+    depsUpgradeOptions: {
+      workflowOptions: {
+        schedule: pj.javascript.UpgradeDependenciesSchedule.WEEKLY,
+      },
+    },
+
     githubOptions: {
       mergeQueue: true,
       pullRequestLintOptions: {


### PR DESCRIPTION
Given that we need to manually give permissions to run workflows for every update, better reduce the frequency to not sit with a giant inventory of PRs.
