### PR TITLE
chore: expect new cli-lib-alpha version

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -15,7 +15,7 @@ jobs:
     environment: integ-approval
     env:
       CI: "true"
-    if: github.event_name != 'merge_group'
+    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
       IS_CANARY: "true"
       CI: "true"
       CLI_LIB_VERSION_MIRRORS_CLI: "true"
-    if: github.event_name != 'merge_group'
+    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -15,7 +15,7 @@ jobs:
     environment: integ-approval
     env:
       CI: "true"
-    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
+    if: github.event_name != 'merge_group'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +54,8 @@ jobs:
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
-    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
+      CLI_LIB_VERSION_MIRRORS_CLI: "true"
+    if: github.event_name != 'merge_group'
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-testing-cli-integ == 'true' }}
     steps:
@@ -100,5 +101,6 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-testing-cli-integ == 'true' }}
     steps:
@@ -101,6 +100,5 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -109,7 +109,7 @@ const repo = configureProject(
       devdirs: ['test'],
       ignorePatterns: ['resources/**/*.ts'],
     },
-    
+
     vscodeWorkspace: true,
     vscodeWorkspaceOptions: {
       includeRootWorkspace: true,
@@ -238,6 +238,7 @@ new CdkCliIntegTestsWorkflow(repo, {
   testEnvironment: TEST_ENVIRONMENT,
   testRunsOn: TEST_RUNNER,
   localPackages: [cliInteg.name],
+  expectNewCliLibVersion: true,
 });
 
 repo.synth();


### PR DESCRIPTION
We used to expect `cli-lib-alpha` to mirror the version of the library; this was true until the new CLI was released.

`cli-lib-alpha` now mirrors the CLI. Flip the flag that says that is true.
