### PR TITLE
feat: interactive input tests

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -199,6 +199,10 @@ export interface CdkCliOptions extends ShellOptions {
   verbose?: boolean;
 }
 
+export interface CdkDestroyCliOptions extends CdkCliOptions {
+  readonly force?: boolean;
+}
+
 /**
  * Prepare a target dir byreplicating a source directory
  */
@@ -366,11 +370,14 @@ export class TestFixture extends ShellHelper {
     ], options);
   }
 
-  public async cdkDestroy(stackNames: string | string[], options: CdkCliOptions = {}) {
+  public async cdkDestroy(stackNames: string | string[], options: CdkDestroyCliOptions = {}) {
     stackNames = typeof stackNames === 'string' ? [stackNames] : stackNames;
 
+    // default to true because most tests don't test user interaction
+    const force = options.force ?? true;
+
     return this.cdk(['destroy',
-      '-f', // We never want a prompt in an unattended test
+      ...(force ? ['-f'] : []), // pass -f if user interaction is not desired
       ...(options.options ?? []),
       ...this.fullStackName(stackNames)], options);
   }

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-destroy-prompts-user.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-destroy-prompts-user.integtest.ts
@@ -1,0 +1,36 @@
+import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { integTest, withDefaultFixture } from '../../lib';
+
+integTest('cdk destroy prompts the user for confirmation', withDefaultFixture(async (fixture) => {
+
+  const stackName = 'test-2';
+  const fullStackName = fixture.fullStackName(stackName);
+
+  fixture.log(`Deploying stack ${fullStackName}`);
+  await fixture.cdkDeploy(stackName);
+
+  fixture.log(`Destroying stack ${fullStackName} and declining prompt`);
+  await fixture.cdkDestroy(stackName, {
+    force: false,
+    interact: [
+      { prompt: /^Are you sure you want to delete/, input: 'no' }
+    ]
+  });
+
+  // assert we didn't destroy the stack
+  const stack = await fixture.aws.cloudFormation.send(new DescribeStacksCommand({ StackName: fullStackName }))
+  expect(stack.Stacks?.length ?? 0).toEqual(1)
+
+  fixture.log(`Destroying stack ${fullStackName} and accepting prompt`);
+  await fixture.cdkDestroy(stackName, {
+    force: false,
+    interact: [
+      { prompt: /^Are you sure you want to delete/, input: 'yes' }
+    ]
+  });
+
+  // assert we did destroy the stack
+  await expect(fixture.aws.cloudFormation.send(new DescribeStacksCommand({ StackName: fullStackName })))
+    .rejects.toThrow(/does not exist/);
+
+}));


### PR DESCRIPTION
Enable integration tests to provide user interaction in order to test interactive commands. 

- Add `interact` property to `ShellOptions` that allows configuring user input based on expected process prompt.
- Match each `stdout` line against the expected prompt to detect when the subprocess requires user input.
- Add example test for responding to `cdk destroy` prompt: **Are you sure you want to delete...**

Resolves https://github.com/aws/aws-cdk/issues/31933