### PR TITLE
fix: cdk-assets v2 test failing on CodeBuild canary

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/smoketest.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/smoketest.integtest.ts
@@ -76,6 +76,9 @@ MAJOR_VERSIONS.forEach(MV => {
       await fixture.shell(['npx', 'cdk-assets', '--path', 'assets.json', '--verbose', 'publish'], {
         modEnv: {
           ...fixture.cdkShellEnv(),
+          // This is necessary for cdk-assets v2, if the credentials are supplied via
+          // config file (which they are on the CodeBuild canaries).
+          AWS_SDK_LOAD_CONFIG: '1',
         },
       });
     }),


### PR DESCRIPTION
In the CodeBuild canaries, we configure credentials via an AssumeRole profile in the config files (whereas on GitHub Actions, we configure credentials via environment variables).

Since cdk-assets v2 uses `aws-sdk-js` v2, we must set an environment variable to make it properly load those config files.

Closes https://github.com/aws/aws-cdk-cli-testing/pull/49