### PR TITLE
fix: Amplify test fails when CLI is installed from Verdaccio

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/tool-integrations/amplify.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/tool-integrations/amplify.integtest.ts
@@ -8,12 +8,24 @@ const TIMEOUT = 1800_000;
 integTest('amplify integration', withToolContext(async (context) => {
   const shell = ShellHelper.fromContext(context);
 
-  await shell.shell(['npm', 'create', '-y', 'amplify@latest']);
-  await shell.shell(['npx', 'ampx', 'configure', 'telemetry', 'disable']);
+  ////////////////////////////////////////////////////////////////////////
+  //  Make sure that create-amplify installs the right versions of the CLI and framework
+  //
 
+  // Install `create-amplify` without running it, then hack the json file with the
+  // package versions in it before we execute.
+  await shell.shell(['npm', 'init', '-y']);
+  await shell.shell(['npm', 'install', '--save-dev', 'create-amplify@latest']);
   // This will create 'package.json' implicating a certain version of the CDK
   await updateCdkDependency(context, context.packages.requestedCliVersion(), context.packages.requestedFrameworkVersion());
-  await shell.shell(['npm', 'install']);
+
+  ////////////////////////////////////////////////////////////////////////
+  //  Run the `npm create` workflow
+  //
+
+  // I tested to confirm that this will use the locally installed `create-amplify`
+  await shell.shell(['npm', 'create', '-y', 'amplify']);
+  await shell.shell(['npx', 'ampx', 'configure', 'telemetry', 'disable']);
 
   await shell.shell(['npx', 'ampx', 'sandbox', '--once'], {
     modEnv: {
@@ -35,9 +47,52 @@ integTest('amplify integration', withToolContext(async (context) => {
 }), TIMEOUT);
 
 async function updateCdkDependency(context: TemporaryDirectoryContext, cliVersion: string, libVersion: string) {
-  const filename = path.join(context.integTestDir, 'package.json');
-  const pj = JSON.parse(await fs.readFile(filename, { encoding: 'utf-8' }));
-  pj.devDependencies['aws-cdk'] = cliVersion;
-  pj.devDependencies['aws-cdk-lib'] = libVersion;
+  const filename = path.join(context.integTestDir, 'node_modules', 'create-amplify', 'lib', 'default_packages.json');
+  const pj: unknown = JSON.parse(await fs.readFile(filename, { encoding: 'utf-8' }));
+
+  // Be extra paranoid about the types here, since we don't fully control them
+  assertIsObject(pj);
+  assertIsStringArray(pj.defaultDevPackages);
+
+  replacePackageVersionIn('aws-cdk', cliVersion, pj.defaultDevPackages);
+  replacePackageVersionIn('aws-cdk-lib', libVersion, pj.defaultDevPackages);
+
   await fs.writeFile(filename, JSON.stringify(pj, undefined, 2), { encoding: 'utf-8' });
+}
+
+/**
+ * Mutably update the given string array, replacing the version of packages with the given name
+ *
+ * We assume the list of packages is a string array of the form
+ *
+ * ```
+ * ["package@version", "package@version", ...]
+ * ```
+ *
+ * It's a failure if we don't find an entry to update.
+ */
+function replacePackageVersionIn(packName: string, version: string, xs: string[]) {
+  let didUpdate = false;
+  for (let i = 0; i < xs.length; i++) {
+    if (xs[i].startsWith(`${packName}@`)) {
+      xs[i] = `${packName}@${version}`;
+      didUpdate = true;
+    }
+  }
+
+  if (!didUpdate) {
+    throw new Error(`Did not find a package version to update for ${packName} in ${JSON.stringify(xs)}`);
+  }
+}
+
+function assertIsObject(xs: unknown): asserts xs is Record<string, unknown> {
+  if (typeof xs !== 'object' || xs === null) {
+    throw new Error(`Expected object, got ${JSON.stringify(xs)}`);
+  }
+}
+
+function assertIsStringArray(xs: unknown): asserts xs is string[] {
+  if (!Array.isArray(xs) || xs.length === 0 || typeof xs[0] !== 'string') {
+    throw new Error(`Expected list of strings, got ${JSON.stringify(xs)}`);
+  }
 }


### PR DESCRIPTION
The Amplify tests (used to) work like this:

- `npm create amplify`, which runs `npx create-amplify`
- Update the `package.json` to point to the correct CLI version
- `npm install` and run the Amplify CLI

However, during the first step (`npx create-amplify`) the Amplify CLI already picks a baked-in CLI version (let's say `aws-cdk@2.1002.0`) and `npm install`s it, before we have had a time to hack the `package.json` file.

This works fine if `2.1002.0` is available to install, but in the case where we have an isolated run with the candidate packages in Verdaccio, only the release candidate is available which will have a version like `2.1002.999`, and the first step of this test fails.

What we do instead is download the installer and change the package version it is about to install by editing one of its data files, `default_packages.json`.