### PR TITLE
fix: ignore notices when checking for stdout behavior

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cli.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cli.integtest.ts
@@ -23,6 +23,7 @@ import { PutObjectLockConfigurationCommand } from '@aws-sdk/client-s3';
 import { CreateTopicCommand, DeleteTopicCommand } from '@aws-sdk/client-sns';
 import { AssumeRoleCommand, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import {
+  CdkCliOptions,
   cloneDirectory,
   integTest,
   randomInteger,
@@ -61,7 +62,7 @@ describe('ci', () => {
     integTest(
       'output to stdout',
       withDefaultFixture(async (fixture) => {
-        const execOptions = {
+        const execOptions: CdkCliOptions = {
           captureStderr: true,
           onlyStderr: true,
           modEnv: {
@@ -70,6 +71,7 @@ describe('ci', () => {
             JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION: 'true',
             JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: 'true',
           },
+          options: ['--no-notices'],
         };
 
         const deployOutput = await fixture.cdkDeploy('test-2', execOptions);


### PR DESCRIPTION
Right now notices get sent to `stdout`. In the future, on GitHub Actions we will send them to `sterr` (see
https://github.com/aws/aws-cdk-cli/pull/221).

However, this change makes the test that assert that we only write to `stdout` fail, so we have to turn off notices first in order to pass the tests.
