### PR TITLE
fix(amplify-integtest): override any peer dependencies on cdk lib

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/tool-integrations/amplify.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/tool-integrations/amplify.integtest.ts
@@ -65,7 +65,7 @@ async function mutateAmplifyDepOnCdk(context: TemporaryDirectoryContext, cliVers
   const packageJson: unknown = JSON.parse(await fs.readFile(packageJsonFile, { encoding: 'utf-8' }));
 
   assertIsObject(packageJson);
-  packageJson["overrides"] = {
+  packageJson.overrides = {
     "aws-cdk-lib": libVersion,
   };
   await fs.writeFile(packageJsonFile, JSON.stringify(packageJson, undefined, 2), { encoding: 'utf-8' })


### PR DESCRIPTION
`@aws-amplify/backend` has a peer dep on `aws-cdk-lib`:

```
  "peerDependencies": {
    "aws-cdk-lib": "^2.168.0",
}
```

This prevents testing using RC versions of `aws-cdk-lib`.

Adding `overrides` into the `package.json` to override any peer dependency requirements on `aws-cdk-lib`.

`npm config set save-exact true` is also needed so that when `create-amplify` runs `npm install`, it does not attempts to use `^<version>` in `package.json`, which will conflicts with the `overrides` mentioned above.