### PR TITLE
chore(cli-integ): remove debug integ workflow patch

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -127,7 +127,7 @@ jobs:
           CDK_MAJOR_VERSION: "2"
           RELEASE_TAG: latest
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bin/run-suite -t "cdk import prompts the user for sns topic arns" --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
+        run: bin/run-suite --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
     strategy:
       fail-fast: false
       matrix:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -242,7 +242,4 @@ new CdkCliIntegTestsWorkflow(repo, {
   localPackages: [cliInteg.name],
 });
 
-// temporary while debugging why the "cdk import prompts the user for sns topic arns" 
-// fails on github.
-repo.tryFindObjectFile('.github/workflows/integ.yml')!.addOverride('jobs.integ_matrix.steps.11.run', 'bin/run-suite -t "cdk import prompts the user for sns topic arns" --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}')
 repo.synth();


### PR DESCRIPTION
As part of debugging a specific test failure in https://github.com/aws/aws-cdk-cli-testing, I committed a projen patch to force the integ suite to only run a specific test. The patch didn't work, but the PR got merged because the test was already fixed apparently due to a prior commit I made. 

I just wasn't patient enough to wait for confirmation after fixing the test.

This removes that patch. 