### PR TITLE
fix: remove logging

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-aws.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-aws.ts
@@ -79,9 +79,6 @@ export function regionPool(): ResourcePool {
     ? process.env.AWS_REGIONS.split(',')
     : [process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? 'us-east-1'];
 
-  // eslint-disable-next-line no-console
-  console.log(`Using regions: ${REGIONS}\n`);
-
   _regionPool = ResourcePool.withResources('aws_regions', REGIONS);
   return _regionPool;
 }


### PR DESCRIPTION
We now run every test in its own process, which means every test prints this log. Remove it, because it's noisy.
