### PR TITLE
fix: also pass `--no-notices` to `cdk diff`

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-ci-true-output-to-stdout.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-ci-true-output-to-stdout.integtest.ts
@@ -18,7 +18,7 @@ integTest(
     };
 
     const deployOutput = await fixture.cdkDeploy('test-2', execOptions);
-    const diffOutput = await fixture.cdk(['diff', fixture.fullStackName('test-2')], execOptions);
+    const diffOutput = await fixture.cdk(['diff', '--no-notices', fixture.fullStackName('test-2')], execOptions);
     const destroyOutput = await fixture.cdkDestroy('test-2', execOptions);
     expect(deployOutput).toEqual('');
     expect(destroyOutput).toEqual('');


### PR DESCRIPTION
The `options` field was being respected by `fixture.deploy` and `fixture.destory`, but not `fixture.cdk`.

Necessary to make https://github.com/aws/aws-cdk-cli/pull/221 pass.