### PR TITLE
chore: run sam local test with `--no-memory-limit`

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
@@ -138,6 +138,9 @@ export class SamIntegrationTestFixture extends TestFixture {
     args.push('--port');
     args.push(port.toString());
 
+    // https://github.com/aws/aws-sam-cli/pull/7892
+    args.push('--no-memory-limit')
+
     // "Press Ctrl+C to quit" looks to be printed by a Flask server built into SAM CLI.
     return this.samShell(['sam', 'local', 'start-api', ...args], 'Press CTRL+C to quit', ()=>{
       return new Promise<ActionOutput>((resolve, reject) => {


### PR DESCRIPTION
To make the tests more portable across different execution platform (e.g CodeBuild).

> I validate that our CodeBuild image contains SAM version [1.134.0](https://github.com/aws/aws-sam-cli/releases/tag/v1.134.0), which contains this feature.

See https://github.com/aws/aws-sam-cli/pull/7892