### PR TITLE
chore: increase max workers

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
   // for the lock. Which is almost never what we actually care about. Set it high.
   testTimeout: 600000,
 
-  maxWorkers: 10,
+  maxWorkers: 50,
   reporters: [
     "default",
     ["jest-junit", { suiteName: "jest tests", outputDirectory: "coverage" }]


### PR DESCRIPTION
Now that atmosphere is live, we can increase the number of workers. This PR already runs on atmosphere with this config and it took 25 minutes for the suite to run.