### PR TITLE
fix: environment acquire timeout too low

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-aws.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-aws.ts
@@ -39,7 +39,7 @@ export function withAws<A extends TestContext>(
   return async (context: A) => {
     if (atmosphereEnabled()) {
       const atmosphere = new AtmosphereClient(atmosphereEndpoint());
-      const allocation = await atmosphere.acquire({ pool: atmospherePool(), requester: context.name });
+      const allocation = await atmosphere.acquire({ pool: atmospherePool(), requester: context.name, timeoutSeconds: 60 * 30 });
       const aws = await AwsClients.forIdentity(allocation.environment.region, {
         accessKeyId: allocation.credentials.accessKeyId,
         secretAccessKey: allocation.credentials.secretAccessKey,

--- a/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
   // for the lock. Which is almost never what we actually care about. Set it high.
   testTimeout: 600000,
 
-  maxWorkers: 10,
+  maxWorkers: 50,
   reporters: [
     "default",
     ["jest-junit", { suiteName: "jest tests", outputDirectory: "coverage" }]

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate--from-stack-creates-deployable-app-csharp.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate--from-stack-creates-deployable-app-csharp.integtest.ts
@@ -3,6 +3,8 @@ import { integTest, withExtendedTimeoutFixture } from "../../../lib";
 
 const language = 'csharp';
 
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
 integTest(
   `cdk migrate --from-stack creates deployable ${language} app`,
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate--from-stack-creates-deployable-app-java.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate--from-stack-creates-deployable-app-java.integtest.ts
@@ -3,6 +3,8 @@ import { integTest, withExtendedTimeoutFixture } from "../../../lib";
 
 const language = 'java';
 
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
 integTest(
   `cdk migrate --from-stack creates deployable ${language} app`,
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate--from-stack-creates-deployable-app-python.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate--from-stack-creates-deployable-app-python.integtest.ts
@@ -3,6 +3,8 @@ import { integTest, withExtendedTimeoutFixture } from "../../../lib";
 
 const language = 'python';
 
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
 integTest(
   `cdk migrate --from-stack creates deployable ${language} app`,
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate--from-stack-creates-deployable-app-typescript.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate--from-stack-creates-deployable-app-typescript.integtest.ts
@@ -3,6 +3,8 @@ import { integTest, withExtendedTimeoutFixture } from "../../../lib";
 
 const language = 'typescript';
 
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
 integTest(
   `cdk migrate --from-stack creates deployable ${language} app`,
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate-deploys-successfully-csharp.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate-deploys-successfully-csharp.integtest.ts
@@ -3,6 +3,8 @@ import { integTest, withCDKMigrateFixture } from "../../../lib";
 
 const language = 'csharp';
 
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
 integTest(
   `cdk migrate ${language} deploys successfully`,
   withCDKMigrateFixture(language, async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate-deploys-successfully-java.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate-deploys-successfully-java.integtest.ts
@@ -3,6 +3,8 @@ import { integTest, withCDKMigrateFixture } from "../../../lib";
 
 const language = 'java';
 
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
 integTest(
   `cdk migrate ${language} deploys successfully`,
   withCDKMigrateFixture(language, async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate-deploys-successfully-python.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate-deploys-successfully-python.integtest.ts
@@ -3,6 +3,8 @@ import { integTest, withCDKMigrateFixture } from "../../../lib";
 
 const language = 'python';
 
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
 integTest(
   `cdk migrate ${language} deploys successfully`,
   withCDKMigrateFixture(language, async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate-deploys-successfully-typescript.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-migrate/cdk-migrate-deploys-successfully-typescript.integtest.ts
@@ -3,6 +3,8 @@ import { integTest, withCDKMigrateFixture } from "../../../lib";
 
 const language = 'typescript';
 
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
 integTest(
   `cdk migrate ${language} deploys successfully`,
   withCDKMigrateFixture(language, async (fixture) => {


### PR DESCRIPTION
We can afford to wait more than 10 minutes, which would higher load configurations.

Also add missing global jest timeouts from tests. Not sure if they got lost during the file split, or were never there to being with. 