### PR TITLE
chore: log partial contents when reading the mutex file

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/xpmutex.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/xpmutex.ts
@@ -165,7 +165,11 @@ export class XpMutex {
       }
 
       // Retry until we've seen the full contents
-      if (contents.endsWith('.')) { return parseInt(contents.substring(0, contents.length - 1), 10); }
+      if (contents.endsWith('.')) {
+        return parseInt(contents.substring(0, contents.length - 1), 10);
+      } else {
+        console.log(`Partial contents in ${this.fileName}: ${contents}`);
+      }
       await sleep(10);
     }
 


### PR DESCRIPTION
The `readPidFile()` function tries to read the contents of the mutex file. If what it reads is not the whole content, it keeps trying for 1 second.