### PR TITLE
fix(cli-integ): interactive `cdk import` test is unstable

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/process.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/process.ts
@@ -90,9 +90,9 @@ class PtyProcess implements IProcess {
     this.process.onData((e) => callback(Buffer.from(e)));
   }
 
-  public onStderr(callback: (chunk: Buffer) => void): void {
-    // in a pty all streams are the same
-    return this.onStdout(callback);
+  public onStderr(_callback: (chunk: Buffer) => void): void {
+    // https://github.com/microsoft/node-pty/issues/71
+    throw new Error('Cannot to register callback for stderr. A tty does not have separate output and error channels');
   }
 
   public onExit(callback: (exitCode: number) => void): void {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-import-interactive.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-import-interactive.integtest.ts
@@ -27,14 +27,18 @@ integTest('cdk import prompts the user for sns topic arns', withDefaultFixture(a
     await fixture.cdk(['import', fullStackName], {
       interact: [
         {
-          prompt: /\(empty to skip\)/,
+          prompt: /Topic1.*\(empty to skip\):/,
           input: topic1Arn,
         },
         {
-          prompt: /\(empty to skip\)/,
+          prompt: /Topic2.*\(empty to skip\):/,
           input: topic2Arn,
         }
-      ]
+      ],
+      modEnv: {
+        // disable coloring because it messes up prompt matching.
+        FORCE_COLOR: '0'
+      }
     });
 
     // assert the stack now has the two topics


### PR DESCRIPTION
Trying to make the test more stable, explanations in the code and comments.