### PR TITLE
fix: global jest timeout is too low

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
 
   // Because of the way Jest concurrency works, this timeout includes waiting
   // for the lock. Which is almost never what we actually care about. Set it high.
-  testTimeout: 600000,
+  testTimeout: 2 * 60 * 60_000,
 
   maxWorkers: 50,
   reporters: [


### PR DESCRIPTION
Currently, the global timeout is set to 10 minutes. However, most of our tests also have [overrides that set it to 2 hours](https://github.com/search?q=repo%3Aaws%2Faws-cdk-cli-testing%20%22jest.setTimeout(2%20*%2060%20*%2060_000)%3B%20%2F%2F%20Includes%20the%20time%20to%20acquire%20locks%2C%20worst-case%20single-threaded%20runtime%22&type=code). There are also tests which don't have this override, for example:

https://github.com/aws/aws-cdk-cli-testing/blob/1103cee20a27edf460251631345b2b980d4e9028/packages/%40aws-cdk-testing/cli-integ/tests/cli-integ-tests/proxy.integtest.ts#L6-L10

Coincidentally, these are the ones failing in the canary runs:

```console
FAIL ./cdk-import-interactive.integtest.js (611.412 s)
647 | ● cdk import prompts the user for sns topic arns
648 |  
649 | thrown: "Exceeded timeout of 600000 ms for a test.
650 | Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
651 |  
652 | 35 \|   const runner = shouldSkip(name) ? test.skip : test;
653 | 36 \|
654 | > 37 \|   runner(name, async () => {
655 | \|   ^
656 | 38 \|     const output = new MemoryStream();
657 | 39 \|
658 | 40 \|     output.write('================================================================\n');
659 |  
660 | at runner (../../lib/integ-test.ts:37:3)
661 | at Object.<anonymous> (cdk-import-interactive.integtest.ts:5:10)
662 |  
663 | FAIL ./proxy.integtest.js (612.584 s)
664 | ● all calls from isolated container go through proxy
665 |  
666 | thrown: "Exceeded timeout of 600000 ms for a test.
667 | Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
668 |  
669 | 35 \|   const runner = shouldSkip(name) ? test.skip : test;
670 | 36 \|
671 | > 37 \|   runner(name, async () => {
672 | \|   ^
673 | 38 \|     const output = new MemoryStream();
674 | 39 \|
675 | 40 \|     output.write('================================================================\n');
676 |  
677 | at runner (../../lib/integ-test.ts:37:3)
678 | at Object.<anonymous> (proxy.integtest.ts:10:10)
679 |  
```

They started failing because we increased the concurrency of the tests, which means the time to acquire locks is much higher now; but still - two hours is enough. 

Instead of hunting down each individual test that doesn't have the 2 hour timeout, or reducing concurrency, lets just make the global timeout 2 hours. 