### PR TITLE
fix(cli-integ): sporadic npm connection resets

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -788,8 +788,27 @@ export async function installNpmPackages(fixture: TestFixture, packages: Record<
     devDependencies: packages,
   }, undefined, 2), { encoding: 'utf-8' });
 
-  // Now install that `package.json` using NPM7
-  await fixture.shell(['node', require.resolve('npm'), 'install']);
+  // we often ECONNRESET from NPM so lets retry. this might be because of high concurrency
+  // which overwhelmes system resources.
+  const timeoutMinutes = 10;
+  const timeoutDate = new Date(Date.now() + timeoutMinutes * 60 * 1000)
+  const retryAfterSeconds = 30;
+
+  while (true) {
+    try {
+      // Now install that `package.json` using NPM7
+      await fixture.shell(['node', require.resolve('npm'), 'install']);
+      break;
+    } catch (e: any) {
+      if (Date.now() < timeoutDate.getTime() && fixture.output.toString().includes('ECONNRESET' )) {
+        fixture.log(`npm install failed due to ECONNRESET. Retrying in ${retryAfterSeconds} seconds...`);
+        await sleep(retryAfterSeconds * 1000)
+        continue;
+      }
+      throw e;
+    }
+  }
+
 }
 
 const ALREADY_BOOTSTRAPPED_IN_THIS_RUN = new Set();


### PR DESCRIPTION
We are [seeing](https://github.com/aws/aws-cdk-cli-testing/actions/runs/14354194579/job/40239880803?pr=80) some sporadic failures during installation of npm packages in tests:

```console
  💻 cp -R /home/runner/work/aws-cdk-cli-testing/aws-cdk-cli-testing/resources/cdk-apps/app/* /tmp/cdk-integ-0uxqgf2j5kce
  💻 node /home/runner/work/aws-cdk-cli-testing/aws-cdk-cli-testing/node_modules/npm/index.js install
  npm ERR! code ECONNRESET
  npm ERR! network aborted
```

Lets applya retry on recoverable errors like these. 