### PR TITLE
fix(cli-integ): atmosphere credentials not used when profile is set via AWS_PROFILE

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/aws.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/aws.ts
@@ -94,6 +94,11 @@ export class AwsClients {
       AWS_ACCESS_KEY_ID: this.identity.accessKeyId,
       AWS_SECRET_ACCESS_KEY: this.identity.secretAccessKey,
       AWS_SESSION_TOKEN: this.identity.sessionToken!,
+
+      // unset any previously used profile because the SDK will prefer
+      // this over static env credentials. this is relevant for tests running on CodeBuild
+      // because we use a profile as our main credentials source.
+      AWS_PROFILE: '',
     } : undefined;
   }
 


### PR DESCRIPTION
In CodeBuild, our initial credentials are configured via a profile `~/.aws/config` and set via the `AWS_PROFILE` env variable. 
This in turn causes the SDK to prefer the profile credentials, even after acquiring an atmosphere environment that provides static env creds:

```console
@aws-sdk/credential-provider-node - defaultProvider::fromEnv WARNING:
--
741 | Multiple credential sources detected:
742 | Both AWS_PROFILE and the pair AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY static credentials are set.
743 | This SDK will proceed with the AWS_PROFILE value.
744 |  
745 | However, a future version may change this behavior to prefer the ENV static credentials.
746 | Please ensure that your environment only sets either the AWS_PROFILE or the
747 | AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair.
```

To fix, lets unset the `AWS_PROFILE` variable if/when static env creds are used.