### PR TITLE
feat(cli-integ): speed up image pulls by logging into ECR public

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -46,6 +46,7 @@ export function withSpecificCdkApp(
       context.output,
       context.aws,
       context.randomString);
+    await fixture.ecrPublicLogin();
 
     let success = true;
     try {
@@ -119,6 +120,7 @@ export function withCdkMigrateApp(
       context.aws,
       context.randomString,
     );
+    await fixture.ecrPublicLogin();
 
     await ensureBootstrapped(fixture);
 

--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cli-lib.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cli-lib.ts
@@ -27,6 +27,7 @@ export function withCliLibIntegrationCdkApp<A extends TestContext & AwsContext &
       context.output,
       context.aws,
       context.randomString);
+    await fixture.ecrPublicLogin();
 
     let success = true;
     try {

--- a/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
@@ -35,6 +35,7 @@ export function withSamIntegrationCdkApp<A extends TestContext & AwsContext>(blo
       context.output,
       context.aws,
       context.randomString);
+    await fixture.ecrPublicLogin();
 
     let success = true;
     try {


### PR DESCRIPTION
When running the suite on CodeBuild, we are seeing timeout failures in the following tests:

- `CDK synth add the metadata properties expected by sam`
- `CDK synth bundled functions as expected`
- `test resource import with construct that requires bundling`
- `deploy new style synthesis to new style bootstrap (with docker image)`
- `all calls from isolated container go through proxy`

These are all tests that either directly pull from `public.ecr.gallery`, or do so as part of `cdk synth`. In both cases, the pull is unauthenticated, and is therefore susceptible to stricter throttling limits, which can significantly slow things down. 

Running the tests individually succeeds, so it must be something to do with the high concurrency introduced by atmosphere.
Lets login to ECR public before every test. I'm not convinced this will solve the issue, but it can't hurt and worst case we eliminate that as a cause and continue investigating.

**Why are we not seeing the same errors when running in GitHub?**

My theory right now is that CodeBuild IP addresses are being throttled much more aggressively than Github ones. 